### PR TITLE
feat: add npm publish beta versions support

### DIFF
--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -1,0 +1,35 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is marked as released
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  push:
+    tags:
+      - 'v*-beta*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -1,6 +1,5 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is marked as released
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
+# This workflow will run tests using node and then publish a package to the npm registry when a release is marked as released
+# For more information see: https://docs.npmjs.com/cli/v7/commands/npm-publish
 name: Node.js Package
 
 on:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,5 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is marked as released
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
+# This workflow will run tests using node and then publish a package to the npm registry when a release is marked as released
+# For more information see: https://docs.npmjs.com/cli/v7/commands/npm-publish
 name: Node.js Package
 
 on:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
This pull request adds a new GitHub Actions workflow for publishing a Node.js package to the npm registry when a release is marked as beta. The workflow includes steps for building and testing the package before publishing it.

## Changes Made
<!-- List the main changes you've made -->
New GitHub Actions workflow:

* [`.github/workflows/npm-publish-beta.yml`](diffhunk://#diff-7e875abce5cd3df7161ae3867e07aa54352c2ad6efe287f749f298b2970ab755R1-R35): Added a workflow that runs tests using Node.js and publishes the package to npm with the beta tag when a release is marked as released.
